### PR TITLE
[DOCUMENTATION]: removing the Amazon copyright

### DIFF
--- a/ec2ifscan
+++ b/ec2ifscan
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-# Copyright (C) 2013 Amazon.com, Inc. or its affiliates.
-# All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License.
-# A copy of the License is located at
-#
-#    http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-# OF ANY KIND, either express or implied. See the License for the
-# specific language governing permissions and limitations under the
-# License.
-
 if [ $UID -ne 0 ]; then
   echo "error: ${0##*/} must be run as root"
   exit 1


### PR DESCRIPTION
The code in the ec2ifscan was not written by anyone at Amazon and therefore I do not believe that it should have the copyright, nor does Amazon probably want the copyright.
